### PR TITLE
enforce en_US.UTF-8 locale

### DIFF
--- a/centos7/Dockerfile
+++ b/centos7/Dockerfile
@@ -24,6 +24,16 @@ RUN sed -i 's@.*default_realm.*@ default_realm = REDHAT.COM@g' /etc/krb5.conf
 # pip3 support
 RUN ln -s /usr/bin/pip3.6 /usr/bin/pip3
 
+# Ensure that we always use UTF-8 and with American English locale
+RUN locale-gen en_US.UTF-8
+
+COPY ./default_locale /etc/default/locale
+RUN chmod 0755 /etc/default/locale
+
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+
 # For supporting arbitrary user IDs
 ADD uid2passwd /usr/local/bin/uid2passwd
 RUN chmod g=u /etc/passwd

--- a/fedora29/Dockerfile
+++ b/fedora29/Dockerfile
@@ -19,6 +19,16 @@ RUN update-ca-trust
 # krbV.Krb5Error: (-1765328160, 'Configuration file does not specify default realm')
 RUN sed -i 's@.*default_realm.*@    default_realm = REDHAT.COM@g' /etc/krb5.conf
 
+# Ensure that we always use UTF-8 and with American English locale
+RUN locale-gen en_US.UTF-8
+
+COPY ./default_locale /etc/default/locale
+RUN chmod 0755 /etc/default/locale
+
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+
 # For supporting arbitrary user IDs
 ADD uid2passwd /usr/local/bin/uid2passwd
 RUN chmod g=u /etc/passwd


### PR DESCRIPTION
Our Python3 preferred encoding defaults to 'ANSI_X3.4-1968' (fancy way
of saying ANSI), which causes some encoing problems for kpet.
This patch fixes it.

Signed-off-by: Jakub Racek <jracek@redhat.com>